### PR TITLE
Fix GET and POST requests

### DIFF
--- a/siege.js
+++ b/siege.js
@@ -126,7 +126,6 @@ siege.request = function(options) {
 
 siege.get = function(url, query) {
   return this.request({
-      // FIXME
       path: url
     , method: 'GET'
     , query: query
@@ -135,7 +134,6 @@ siege.get = function(url, query) {
 
 siege.post = function(url, body) {
   return this.request({
-      // FIXME
       path: url
     , method: 'POST'
     , body: body

--- a/siege_attack.js
+++ b/siege_attack.js
@@ -175,6 +175,11 @@ module.exports = function(options, callback) {
 
       // Add QueryString to URL for GET Requests with Parameters
       if(requestOptions.method === 'GET' && task.query) {
+          // Reset query string if present
+          var hasQuery = requestOptions.path.indexOf('?')
+          if(hasQuery > 0) {
+            requestOptions.path = requestOptions.path.substring(0,hasQuery)
+          }
           requestOptions.path = requestOptions.path + "?" + querystring.stringify(task.query)
       }
 

--- a/siege_attack.js
+++ b/siege_attack.js
@@ -164,10 +164,21 @@ module.exports = function(options, callback) {
         headers['Cookie'] = jar.getCookies(cookieAccessInfo).map(function(cookie) {return cookie.toValueString()}).join(';')
       }
 
+      // Add POST Headers for POST Requests
+      if(requestOptions.method === 'POST' && task.body) {
+        headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        headers['Content-Length'] = querystring.stringify(task.body).length
+      }
+
       var reqStartTime = Date.now();
       var req;
+
+      // Add QueryString to URL for GET Requests with Parameters
+      if(requestOptions.method === 'GET' && task.query) {
+          requestOptions.path = requestOptions.path + "?" + querystring.stringify(task.query)
+      }
+
       if (options.sslProtocol && options.sslProtocol === true) {
-        console.log("here");
         req = https.request(requestOptions,handleRequest);
       } else {
         req = http.request(requestOptions,handleRequest);
@@ -218,6 +229,8 @@ module.exports = function(options, callback) {
           endRequest()
       })
 
+
+      // Add POST Body for POST requests
       if(requestOptions.method === 'POST' && task.body) {
           req.write(querystring.stringify(task.body));
       }


### PR DESCRIPTION
Properly sends POST headers for POST requests.

Adds query string for GET requests that have query parameters.